### PR TITLE
show methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Suppressor"]

--- a/src/MFrontInterface.jl
+++ b/src/MFrontInterface.jl
@@ -27,7 +27,7 @@ end
 export load, BehaviourData, get_variable_offset, get_internal_state_variables
 export get_hypothesis, set_time_increment!, set_external_state_variable!
 export get_final_state, update, get_gradients, get_initial_state, integrate
-export get_initial_state
+export get_initial_state, get_parameters
 
 function Base.show(io::IO,m::BehaviourAllocated)
     print(io, "behaviour ", get_behaviour(m))
@@ -52,6 +52,21 @@ function Base.show(io::IO, m::RealsVectorRef)
     end
 end
 
+function Base.iterate(iter::StringsVectorAllocated, state=(1, 1))
+    element, count = state
+    if count > length(iter)
+        return nothing
+    end
+    return (iter[element], (element + 1, count + 1))
+end
+
+function Base.show(io::IO, m::StringsVectorAllocated)
+    println(io, length(m),"-element StringsVector")
+    for i in m
+        println(io, " ", i)
+    end
+end
+
 # function Base.show(io::IO,m::BehaviourDataAllocated)
 #     print(io, "Behaviour Data ")
 # end
@@ -62,5 +77,5 @@ using .behaviour
 export load, BehaviourData, get_variable_offset, get_internal_state_variables
 export get_hypothesis, set_time_increment!, set_external_state_variable!
 export get_final_state, update, get_gradients, get_initial_state, integrate
-export get_initial_state
+export get_initial_state, get_parameters
 end # module MFront`

--- a/src/MFrontInterface.jl
+++ b/src/MFrontInterface.jl
@@ -27,11 +27,12 @@ end
 export load, BehaviourData, get_variable_offset, get_internal_state_variables
 export get_hypothesis, set_time_increment!, set_external_state_variable!
 export get_final_state, update, get_gradients, get_initial_state, integrate
-export get_initial_state, get_parameters
+export get_initial_state, get_parameters, get_external_state_variables
 
 function Base.show(io::IO,m::BehaviourAllocated)
     print(io, "behaviour ", get_behaviour(m))
-    print(io, " in shared library Behaviour for modelling hypothesis ")
+    print(io, " in shared library ", get_library(m))
+    print(io, " for modelling hypothesis ")
     print(io, toString(get_hypothesis(m)))
     print(io, " generated from ", get_source(m), " using TFEL version: ")
     print(io, get_tfel_version(m), ".")
@@ -67,9 +68,21 @@ function Base.show(io::IO, m::StringsVectorAllocated)
     end
 end
 
-# function Base.show(io::IO,m::BehaviourDataAllocated)
-#     print(io, "Behaviour Data ")
-# end
+function Base.iterate(iter::VariablesVectorAllocated, state=(1, 1))
+    element, count = state
+    if count > length(iter)
+        return nothing
+    end
+    return (iter[element], (element + 1, count + 1))
+end
+
+function Base.show(io::IO, m::VariablesVectorAllocated)
+    println(io, length(m),"-element VariablesVector")
+    for i in m
+        println(io, " ", get_name(i))
+    end
+end
+
 
 end # module behaviour
 # Re-exporting behaviour model functions
@@ -77,5 +90,5 @@ using .behaviour
 export load, BehaviourData, get_variable_offset, get_internal_state_variables
 export get_hypothesis, set_time_increment!, set_external_state_variable!
 export get_final_state, update, get_gradients, get_initial_state, integrate
-export get_initial_state, get_parameters
+export get_initial_state, get_parameters, get_external_state_variables
 end # module MFront`

--- a/src/MFrontInterface.jl
+++ b/src/MFrontInterface.jl
@@ -30,9 +30,26 @@ export get_final_state, update, get_gradients, get_initial_state, integrate
 export get_initial_state
 
 function Base.show(io::IO,m::BehaviourAllocated)
-    println(io, "libBehaviour: generated from ", get_source(m))
-    println(io, "name of the behaviour: ", get_behaviour(m))
-    print(io, "TFEL version: ", get_tfel_version(m))
+    print(io, "behaviour ", get_behaviour(m))
+    print(io, " in shared library Behaviour for modelling hypothesis ")
+    print(io, toString(get_hypothesis(m)))
+    print(io, " generated from ", get_source(m), " using TFEL version: ")
+    print(io, get_tfel_version(m), ".")
+end
+
+function Base.iterate(iter::RealsVectorRef, state=(1, 1))
+    element, count = state
+    if count > length(iter)
+        return nothing
+    end
+    return (iter[element], (element + 1, count + 1))
+end
+
+function Base.show(io::IO, m::RealsVectorRef)
+    println(io, length(m),"-element RealsVector")
+    for i in m
+        println(io, " ", i)
+    end
 end
 
 # function Base.show(io::IO,m::BehaviourDataAllocated)

--- a/src/MFrontInterface.jl
+++ b/src/MFrontInterface.jl
@@ -28,6 +28,17 @@ export load, BehaviourData, get_variable_offset, get_internal_state_variables
 export get_hypothesis, set_time_increment!, set_external_state_variable!
 export get_final_state, update, get_gradients, get_initial_state, integrate
 export get_initial_state
+
+function Base.show(io::IO,m::BehaviourAllocated)
+    println(io, "libBehaviour: generated from ", get_source(m))
+    println(io, "name of the behaviour: ", get_behaviour(m))
+    print(io, "TFEL version: ", get_tfel_version(m))
+end
+
+function Base.show(io::IO,m::BehaviourDataAllocated)
+    print(io, "Behaviour Data ")
+end
+
 end # module behaviour
 # Re-exporting behaviour model functions
 using .behaviour

--- a/src/MFrontInterface.jl
+++ b/src/MFrontInterface.jl
@@ -35,9 +35,9 @@ function Base.show(io::IO,m::BehaviourAllocated)
     print(io, "TFEL version: ", get_tfel_version(m))
 end
 
-function Base.show(io::IO,m::BehaviourDataAllocated)
-    print(io, "Behaviour Data ")
-end
+# function Base.show(io::IO,m::BehaviourDataAllocated)
+#     print(io, "Behaviour Data ")
+# end
 
 end # module behaviour
 # Re-exporting behaviour model functions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using MFrontInterface
 using DelimitedFiles
+using Suppressor
 using Test
 lpath = MFrontInterface.lpath
 
@@ -13,5 +14,6 @@ eps = 1.e-12
     include("test_binary_dependencies.jl")
     if Sys.islinux()
         include("test_norton_model.jl")
+        include("test_show_methods.jl")
     end
 end

--- a/test/test_show_methods.jl
+++ b/test/test_show_methods.jl
@@ -1,7 +1,12 @@
 @testset "show methods" begin
     b = load("data/libBehaviour.so","Norton",mbv.Tridimensional)
     BehaviourAllocated_out = @capture_out show(b)
-    BehaviourAllocated_expected = "libBehaviour: generated from Norton.mfront\nname of the behaviour: Norton\nTFEL version: 3.3.0-dev"
+    BehaviourAllocated_expected = "behaviour Norton in shared library Behaviour for modelling hypothesis Tridimensional generated from Norton.mfront using TFEL version: 3.3.0-dev."
     @test BehaviourAllocated_out == BehaviourAllocated_expected
+
+    d = BehaviourData(b)
+    RealsVectorRef_out = @capture_out show(get_internal_state_variables(get_initial_state(d)))
+    RealsVectorRef_expected = "7-element RealsVector\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n"
+    @test RealsVectorRef_expected == RealsVectorRef_out
 
 end

--- a/test/test_show_methods.jl
+++ b/test/test_show_methods.jl
@@ -9,4 +9,8 @@
     RealsVectorRef_expected = "7-element RealsVector\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n 0.0\n"
     @test RealsVectorRef_expected == RealsVectorRef_out
 
+    StringsVectorAllocated_out = @capture_out show(get_parameters(b))
+    StringsVectorAllocated_expected = "11-element StringsVector\n epsilon\n YoungModulus\n PoissonRatio\n RelativeValueForTheEquivalentStressLowerBoundDefinition\n K\n E\n A\n minimal_time_step_scaling_factor\n maximal_time_step_scaling_factor\n theta\n numerical_jacobian_epsilon\n"
+    @test StringsVectorAllocated_expected == StringsVectorAllocated_out
+
 end

--- a/test/test_show_methods.jl
+++ b/test/test_show_methods.jl
@@ -1,0 +1,7 @@
+@testset "show methods" begin
+    b = load("data/libBehaviour.so","Norton",mbv.Tridimensional)
+    BehaviourAllocated_out = @capture_out show(b)
+    BehaviourAllocated_expected = "libBehaviour: generated from Norton.mfront\nname of the behaviour: Norton\nTFEL version: 3.3.0-dev"
+    @test BehaviourAllocated_out == BehaviourAllocated_expected
+
+end

--- a/test/test_show_methods.jl
+++ b/test/test_show_methods.jl
@@ -1,7 +1,7 @@
 @testset "show methods" begin
     b = load("data/libBehaviour.so","Norton",mbv.Tridimensional)
     BehaviourAllocated_out = @capture_out show(b)
-    BehaviourAllocated_expected = "behaviour Norton in shared library Behaviour for modelling hypothesis Tridimensional generated from Norton.mfront using TFEL version: 3.3.0-dev."
+    BehaviourAllocated_expected = "behaviour Norton in shared library data/libBehaviour.so for modelling hypothesis Tridimensional generated from Norton.mfront using TFEL version: 3.3.0-dev."
     @test BehaviourAllocated_out == BehaviourAllocated_expected
 
     d = BehaviourData(b)
@@ -13,4 +13,8 @@
     StringsVectorAllocated_expected = "11-element StringsVector\n epsilon\n YoungModulus\n PoissonRatio\n RelativeValueForTheEquivalentStressLowerBoundDefinition\n K\n E\n A\n minimal_time_step_scaling_factor\n maximal_time_step_scaling_factor\n theta\n numerical_jacobian_epsilon\n"
     @test StringsVectorAllocated_expected == StringsVectorAllocated_out
 
+    set_external_state_variable!(get_final_state(d), "Temperature", 293.15)
+    VariablesVectorAllocated_out = @capture_out show(get_external_state_variables(b))
+    VariablesVectorAllocated_expected = "1-element VariablesVector\n Temperature\n"
+    @test VariablesVectorAllocated_expected == VariablesVectorAllocated_out
 end


### PR DESCRIPTION
Here is the updated usage example:
```julia
julia> b = load("data/libBehaviour.so","Norton", mbv.Tridimensional)
behaviour Norton in shared library data/libBehaviour.so for modelling hypothesis Tridimensional generated from Norton.mfront using TFEL version: 3.3.0-dev.

julia> d = BehaviourData(b)
MFrontInterface.behaviour.BehaviourDataAllocated(Ptr{Nothing} @0x0000000002a50610)

julia> get_internal_state_variables(get_initial_state(d))
7-element RealsVector
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0


julia> get_parameters(b)
11-element StringsVector
 epsilon
 YoungModulus
 PoissonRatio
 RelativeValueForTheEquivalentStressLowerBoundDefinition
 K
 E
 A
 minimal_time_step_scaling_factor
 maximal_time_step_scaling_factor
 theta
 numerical_jacobian_epsilon


julia> get_external_state_variables(b)
1-element VariablesVector
 Temperature


julia> 

```


@thelfer here is an example of overloading `Base.show` function to get nicer interactive user experience. You know the internals better, is there something we should add or remove? I would like to use `get_parameters`, but I couldn't figured out how to use it. Can you help me creating another method for another type?