### PR TITLE
Initial package Citation information

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,8 @@
+@inproceedings{frondelius2019mfrontinterface,
+    title={MFrontInterface.jl: MFront material models in Julia{FEM}},
+    author={Tero Frondelius and Thomas Helfer and Ivan Yashchuk and Joona Vaara  and Anssi Laukkanen},
+    editor={H. Koivurova and A. H. Niemi},
+    booktitle={Proceedings of the 32nd Nordic Seminar on Computational Mechanics},
+    year={2019},
+    place={Oulu}
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@
 [docs-stable-url]: https://juliafem.github.io/MFrontInterface.jl/stable
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://juliafem.github.io/MFrontInterface.jl/latest
+
+
+## Citation
+
+If you like our package, please consider citing with the infromation in [CITATION.bib](https://github.com/JuliaFEM/MFrontInterface.jl/blob/master/CITATION.bib):
+
+```
+@inproceedings{frondelius2019mfrontinterface,
+    title={MFrontInterface.jl: MFront material models in Julia{FEM}},
+    author={Tero Frondelius and Thomas Helfer and Ivan Yashchuk and Joona Vaara  and Anssi Laukkanen},
+    editor={H. Koivurova and A. H. Niemi},
+    booktitle={Proceedings of the 32nd Nordic Seminar on Computational Mechanics},
+    year={2019},
+    place={Oulu}
+}
+```


### PR DESCRIPTION
[Here is the discourse discussion](https://discourse.julialang.org/t/replacing-citation-bib-with-a-standard-metadata-format/26871). And here is  [the conclusion](https://discourse.julialang.org/t/replacing-citation-bib-with-a-standard-metadata-format/26871/22):
> This seems like a classic “perfect is the enemy of the good” situation: CodeMeta is the perfect here, CITATION.bib is the good. The CITATION.bib convention is truly the dumbest, simplest thing that could possibly work, but it’s extremely pragmatic. The CodeMeta thing is better, smarter, more general… and something that few people seem to know or want to do. To that end, I’d like to propose the following:

> - Those who don’t want to deal with CoteMeta should just write CITATION.bib files by hand;
> - Authors are encouraged to use CodeMeta as the source of truth and generate CITATION.bib files to check into packages.

> It may be possible to write tooling to reverse generate CodeMeta data from the CITATION.bib format, which should be used as a one-time utility for those who want to transition, after which CodeMeta should be considered the source of truth. This way people using LaTeX for publication only ever need to look at CITATION.bib and don’t need to install any tooling to parse and format CodeMeta files just to cite something.